### PR TITLE
CANThrottle_rework

### DIFF
--- a/throttle_rework/src/OCEANOS_CAN/OCEANOS_CAN.cpp
+++ b/throttle_rework/src/OCEANOS_CAN/OCEANOS_CAN.cpp
@@ -1,0 +1,45 @@
+#include "OCEANOS_CAN.h"
+OCEANOS_CAN::OCEANOS_CAN(int VESC_id){
+	vesc_id = VESC_id;
+}
+
+void OCEANOS_CAN::receive_Message(CAN_message_t &frame)
+{
+	int32_t current_id = this->vesc_id;
+
+		if ((0x900 | current_id) == (frame.id)){
+			ind = 0;		
+			this->motor.rpm = buffer_get_int32(frame.buf, &ind)/5;
+			this->motor.motor_current = buffer_get_float16(frame.buf, 1e2, &ind);
+			this->motor.duty_cycle = buffer_get_float16(frame.buf, 1e2, &ind);
+		}else if((0x1000 | current_id) == (frame.id)){
+			ind = 0;
+			this->motor.fault = buffer_get_uint8(frame.buf, &ind);
+			this->motor.id = buffer_get_uint8(frame.buf, &ind);
+		}
+		else if ((0x1B00 | current_id) == (frame.id)){
+			ind = 4;
+			this->motor.voltage = buffer_get_float16(frame.buf, 1e1, &ind);
+    }
+}
+
+void OCEANOS_CAN::printFrame(CAN_message_t &msg, int mailbox)
+{
+	Serial.print("MB "); Serial.print(msg.mb);
+	Serial.print("  OVERRUN: "); Serial.print(msg.flags.overrun);
+	Serial.print("  LEN: "); Serial.print(msg.len);
+	Serial.print(" EXT: "); Serial.print(msg.flags.extended);
+	Serial.print(" TS: "); Serial.print(msg.timestamp);
+	Serial.print(" ID: "); Serial.print(msg.id, HEX);
+	Serial.print(" Buffer: ");
+	for ( uint8_t i = 0; i < msg.len; i++ ) {
+		Serial.print(msg.buf[i], HEX); Serial.print(" ");
+	} Serial.println();
+}
+
+bool OCEANOS_CAN::frameHandler(CAN_message_t &frame, int mailbox, uint8_t controller)
+{
+		// printFrame(frame, mailbox);
+		receive_Message(frame);
+		return true;
+}

--- a/throttle_rework/src/OCEANOS_CAN/OCEANOS_CAN.h
+++ b/throttle_rework/src/OCEANOS_CAN/OCEANOS_CAN.h
@@ -1,0 +1,64 @@
+#ifndef OCEANOS_CAN_h
+#define OCEANOS_CAN_h
+
+#include <FlexCAN_T4.h>
+#include <TimeLib.h>
+#include "buffer.h"
+
+
+
+#define MAXEQ(A,B) (A) = max((A), (B))
+
+// --------------------------------------------------------
+
+class Throttle_Data{
+    public:
+        int8_t value;   // Requested Power [-100;100]
+        bool zero;      // If set, throttle has gone to zero after startup
+
+};
+
+// --------------------------------------------------------
+
+class Motor_Data{
+    public:
+        float motor_current;        // Motor current (quadrature current)
+        float input_current;        // VESC Input Current
+        float duty_cycle;           // VESC Duty Cycle
+        int32_t rpm;                // Motor RPMs 
+        float voltage;              // VESC Input Voltage
+        float temp_motor;           // Motor Temperature
+        float temp_mos_max;         // Highest MOS Temperature DOSE NOT COME FROM THE CAN BUS
+        float temp_mos_1;           // VESC MOS 1 Temperature
+        float temp_mos_2;           // VESC MOS 2 Temperature
+        float temp_mos_3;           // VESC MOS 3 Temperature
+        uint8_t fault;              // VESC Fault Code
+        uint8_t id;                 // VESC ID
+        int16_t asked_current;      // Motors Current Resquested
+        
+};
+// --------------------------------------------------------
+
+
+//CanListener is a dummy class FlexCANT4 uses to service interrupts
+class OCEANOS_CAN : public CANListener 
+{
+private:
+    static time_t getTeensy3Time();
+	int32_t vesc_id;
+public:
+    int *filters;
+    int32_t ind = 0;
+    uint8_t status;
+
+
+    Throttle_Data throttle;
+    Motor_Data motor;
+
+    OCEANOS_CAN(int VESC_id);  
+    void receive_Message(CAN_message_t &frame);
+    void printFrame(CAN_message_t &frame, int mailbox);
+    bool frameHandler(CAN_message_t &frame, int mailbox, uint8_t controller); //overrides the parent version so we can actually do something 
+};
+
+#endif

--- a/throttle_rework/src/OCEANOS_CAN/README.md
+++ b/throttle_rework/src/OCEANOS_CAN/README.md
@@ -1,0 +1,390 @@
+# TSB SM01's CAN protocol
+
+Copyright (C) 2021  Técnico Solar Boat
+
+This repository and its contents  is free software: you can redistribute 
+it and/or modify it under the terms of the GNU General Public License 
+as published by the Free Software Foundation, either version 3 of the 
+License, or (at your option) any later version.
+
+The content of this repository is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+You can contact Técnico Solar Boat by email at: tecnico.solarboat@gmail.com
+or via our facebook page at https://fb.com/tecnico.solarboat
+
+
+⚠️ **SM01's CAN Bus needs to run at 500 kbps given that the Fuel Cell is limited to this speed.** ⚠️
+
+⚠️ **CAN TSB now uses 4 bits for Source and 5 bits for Data.** ⚠️
+
+⚠️ **CAN TSB now uses tonton81's FlexCAN_T4 library check the example at the end of this README** ⚠️
+
+
+#### Índice
+
+- [Message Structure](#Mensagens)
+- [ID Structure](#ID)
+- [Code](#Código)
+
+<a name="Mensagens"/>
+
+## Message Structure
+![JC](https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/CAN-Bus-frame_in_base_format_without_stuffbits.svg/709px-CAN-Bus-frame_in_base_format_without_stuffbits.svg.png)
+
+On the code, only ID, DL (message length) and DB (message content) need to be defined.
+
+<a name="ID"/>
+
+### ID Structure
+
+| Priority bits |  Data ID | Source ID |
+|:-------------:|:--------:|:---------:|
+|    2 bits     |  5 bits  |  4 bits   |
+
+
+#### Priority bits
+
+- Defines the message priority
+- 00 maximum priority
+- 11 lowest priority
+
+#### Data ID
+
+- Defines the message content
+- With respect to each device
+
+#### Source ID
+
+- Defines which node sent the message
+- Together with the Data ID defines which message was sent
+
+| Source ID (4 bits) |           Node          |
+|:------------------:|:-----------------------:|
+|       0x0          |  [Throttle](#0x0)       |
+|       0x1          |  [BMS](#0x1)            |
+|       0x2          |  [Fuel Cell](#0x2)      |
+|       -          |  [Motor](#0x3)          |
+|	    0x5		     |	[Screen](#0x5)         |
+|		0x6		     |  [Current Sensor](#0x6) |
+|       0x7          |  [Fuse Board](#0x7)     |
+|       0x8          |  [Power Box](#0x8)        |
+|       0x9          |  [H2 Board](#0x9)       |
+
+<br/>
+
+ ⚠️ Scale is scale argument you need to pass to the  decoding function see: **[buffer.c](https://gitlab.com/tecnicosb/tsb-es/2021/can_tsb/-/blob/master/src/buffer.cpp)** If there is no scale the int function must be used. Otherwise, float functions must be used. ⚠️
+
+<a name="0x0"/>
+
+## Throttle:
+### value (CAN ID: 0x10)
+**LEN = 2**
+|  Offset |   Type   |        Name       |       Scale        |         Description           |
+|:-------:|:--------:|:-----------------:|:------------------:|:-----------------------------:|
+|    0    |  int8_t  |        Value      |                    | Requested power \[-100;100\]  |
+|    1    |          |       Status      |          -         |          Status bits          |
+
+#### Status bits: 
+| Position |      Message     | Description |
+|:--------:|:----------------:|:-----------:|
+|     7    |         -        |             |
+|     6    |         -        |             |
+|     5    |         -        |             |
+|     4    |         -        |             |
+|     3    |         -        |             |
+|     2    |         -        |             |
+|     1    |         -        |             |
+|     0    |       Zero       | If set, throttle has gone to zero after startup |
+
+<a name="0x1"/>
+
+## BMS:
+
+We did not had time to properly implement this code.
+
+<a name="0x2"/>
+
+## Fuel Cell:
+
+Documents are under NDA.
+
+<a name="0x3"/>
+
+## Motor Controller PCB:
+
+#### These messages are now broadcasted by the VESCs directly to the boat's CAN Bus, **they use EXTENDED CAN IDs**. To do a slightly modified version of VESC firmware is used so that the telemetry has the data we want.
+
+### motor_current (CAN EXT ID: 0x901)
+**LEN = 8**
+
+|  Offset |    Type    |        Name       |          Scale           |        Description         |
+|:-------:|:----------:|:-----------------:|:------------------------:|:--------------------------:|
+|    0    |  int32_t   |  Motor_current    |			     1e2		        | Motor Current 	           |
+|    4    |  int32_t   |Motor_input_current|           1e2            | VESC Motor Input Current   |
+
+
+### motor_duty_rpm_voltage (CAN EXT ID: 0xE01)
+**LEN = 8**
+
+|  Offset |    Type    |        Name       |          Scale           |        Description         |
+|:-------:|:----------:|:-----------------:|:------------------------:|:--------------------------:|
+|    0    |  int16_t   |  Duty_cycle   	   |			      1e2           | VESC duty cycle            |
+|    2    |  int32_t   |  RPM   		       |            1e0           | Motor RPMs     		         |
+|    6    |  int16_t   |  Motor_voltage 	 |            1e1           | VESC input voltage         |
+
+
+### motor_temperatures (CAN EXT ID: 0xF01)
+**LEN = 8**
+
+|  Offset |    Type    |        Name       |          Scale           |        Description         |
+|:-------:|:----------:|:-----------------:|:------------------------:|:--------------------------:|
+|    0    |  int16_t   | Temp_motor		     |		      	1e1           | Motor Temperature          |
+|    2    |  int16_t   | Temp_mos_1    	   |            1e1           | VESC Mos 1 Temp.     	     |
+|    4    |  int16_t   | Temp_mos_2        |            1e1           | VESC Mos 2 Temp.           |
+|    6    |  int16_t   | Temp_mos_3	       |            1e1           | VESC Mos 3 Temp.           |
+
+
+### motor_fault_id_asked_current (CAN EXT ID: 0x1001)
+**LEN = 4**
+
+|  Offset |    Type    |        Name       |          Scale           |        Description         |
+|:-------:|:----------:|:-----------------:|:------------------------:|:--------------------------:|
+|    0    |  uint8_t   | Fault 			       |					  -             | VESC Fault code            |
+|    1    |  uint8_t   | ID          	     |            -             | VESC id      	             |
+|    2    |  int16_t   | Asked_current     |            -             | Throttle asked current     |
+
+
+<a name="0x5"/>
+
+## Screen:
+### new_sd_log_file (CAN ID: 0x605)
+**LEN = 0**
+Content does not matter, just send message with empty buffer.
+
+<a name="0x6"/>
+
+## CAB 500-C/SP5 Current Sensor (LEM):
+
+For more information regarding this sensor messages check [this documents](https://gitlab.com/tecnico.solar.boat/2021/SM01/-/tree/main/Datasheets/LEM%20CAB500%20Current%20Sensor). **Be aware that we are not using the default CAN ID's shown on LEM documents.**
+
+### CAB500_Ip frame (CAN ID: 0x606)
+**LEN = 8**
+
+<img src="Auxiliary%20Files/CAB500_IP_Frame.png"  width="60%">
+
+<img src="Auxiliary%20Files/CAB500_Errors.png"  width="60%">
+
+
+### UDS_CLIENT (CAN ID: 0x406)
+**LEN = 8**
+
+### UDS_SERVER (CAN ID: 0x506)
+**LEN = 8**
+
+<a name="0x7"/>
+
+## Fuse Board:
+### status (CAN ID: 0x607)
+**LEN = 2**
+
+|  Offset |   Type    |        Name       |     Scale     |           Description            |
+|:-------:|:---------:|:-----------------:|:-------------:|:--------------------------------:|
+|    0    |  int8_t  |     current_24    |      1e1      | current in 24V system in A       |
+|    1    |  int8_t  |     current_48    |      1e1      | current in 48V system in A       | 
+
+---
+
+<a name="0x8"/>
+
+## Power Box:
+
+### PB_GPS (CAN ID: 0x618)
+**LEN = 8**
+
+| Offset |   Type  |    Name   |     Scale       |                  Description                  |
+|:------:|:-------:|:---------:|:---------------:|:---------------------------------------------:|
+|    0   | int32_t |  Latitude | 2<sup>+24</sup> |  Boat Latitude in decimal degrees format (DD) |
+|    4   | int32_t | Longitude | 2<sup>+23</sup> | Boat Longitude in decimal degrees format (DD) |
+
+### PB_Vel_Angle_Status (CAN ID: 0x628)
+**LEN = 5**
+
+| Offset |   Type  |  Name  | Scale |                   Description                   |
+|:------:|:-------:|:------:|:-----:|:-----------------------------------------------:|
+|    0   | int16_t |  Speed |  1e2  |                  Speed in knots                 |
+|    2   | uint16_t|  Angle |   -   | Direction with north (0-360) - Counterclockwise |
+|    4   |         | Status |   -   |                 Status bits                     |
+
+#### Status messages:
+| Position |      Message     | Description                  |
+|:--------:|:----------------:|:----------------------------:|
+|     7    |         -        |                              |
+|     6    |         -        |                              |
+|     5    |         -        |                              |
+|     4    | KillSwitch_Sense | 1 means the killswitch is on |
+|     3    |  FuelCell_Sense  | 1 means there is voltage     |
+|     2    |  FuelCell_Relay  | 1 means Relay is closed      |
+|     1    |   Motor_Relay    | 1 means Relay is closed      |
+|     0    | PreCharge_Relay  | 1 means Relay is closed      |
+
+
+
+<a name="0x9"/>
+
+## H2 Board:
+### HB_Temp_Humid (CAN ID: 0x619)
+**LEN = 8**
+
+| Offset |  Type   |       Name       | Scale |         Description        |
+|:------:|:-------:|:----------------:|:-----:|:--------------------------:|
+|    0   | uint8_t |    Temp_H2_In    |   -   |    Temperature H2 Inlet    |
+|    1   | uint8_t |    Temp_H2_Out   |   -   |    Temperature H2 Outlet   |
+|    2   | uint8_t |    Humid_H2_In   |   -   |      Humidity H2 Inlet     |
+|    3   | uint8_t |   Humid_H2_Out   |   -   |     Humidity H2 Outlet     |
+|    4   | uint8_t |    Temp_Air_In   |   -   |    Temperature Air Inlet   |
+|    5   | uint8_t |   Humid_Air_In   |   -   |      Humidity Air Inlet    |
+|    6   | uint8_t |  Temp_Cooling_In |   -   |  Temperature Cooling Inlet |
+|    7   | uint8_t | Temp_Cooling_Out |   -   | Temperature Cooling Outlet |
+
+### HB_Pressure_Status (CAN ID: 0x629)
+**LEN = 8**
+
+| Offset |   Type   |       Name       | Scale |        Description       |
+|:------:|:--------:|:----------------:|:-----:|:------------------------:|
+|    0   |  int8_t  |  Pressure_H2_In  |  1e1  | Pressure H2 Inlet        |
+|    1   |  int8_t  | Pressure_H2O_Out |  1e1  | Pressure H2O Outlet      |
+|    2   | uint16_t |    RPM_Blower    |   -   | RPMs of Air blower       |
+|    4   |  int16_t |     Flow_Air     |  1e1  | Air flow Inlet           |
+|    6   |  uint8_t |  Temp_Blower     |   -   | Temperature Air Blower   |
+|    7   |          |      Status      |   -   | Status bits              |
+
+#### Status messages:
+| Position |        Message       | Description |
+|:--------:|:--------------------:|-------------|
+|     7    |           -          |             |
+|     6    |           -          |             |
+|     5    |           -          |             |
+|     4    |           -          |             |
+|     3    |           -          |             |
+|     2    |  Status_H2O_Solen    | 1 means valve is open |
+|     1    |  Status_H2_Solen     | 1 means valve is open |
+|     0    |  Status_Cooling_Pump | 1 means pump is ON    |
+
+#### Messages location on vessel
+<img src="Auxiliary Files/SM01_Overview.png"  width="100%">
+
+
+<a name="Código"/>
+
+
+#### Requirements
+
+- **[VSCode](https://code.visualstudio.com/)**
+- **[Platformio](https://platformio.org/)**
+- **[tonton81's FlexCAN_T4](https://github.com/tonton81/FlexCAN_T4)**
+
+
+### Example
+
+```c++
+#include <Arduino.h>
+#include "CAN_TSB_H2.h"
+#if defined(__AVR_AT90CAN32__) || defined(__AVR_AT90CAN64__) || defined(__AVR_AT90CAN128__)
+  #include "avr_can.h"
+#endif
+
+TSB_CAN canMessageHandler;
+CAN_message_t to_send; // One for each CAN ID that needs to be sent 
+
+#if defined(__IMXRT1062__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+  // Declare your CAN interface, CAN0 available for Teensy 3.2/5 CAN 0 and 1 for Teensy 3.6 
+  // CAN 1, 2 and 3 avalible for Teensy 4.X
+  FlexCAN_T4<CAN0, RX_SIZE_256, TX_SIZE_16> Can0; // <- This name can be whatever you like but this is the name used to send commands to the interface
+#endif
+
+void initCAN_Messages(){ // Inicialise the message fixed parameters, do it for all messages
+  to_send.flags.extended = 0;
+  to_send.id = 0x04;
+  to_send.len = 4;
+  // if you whant to be sure that messages are sent in the order they are generated set this to 1
+  // otherwise you don't need to set it.
+  // to_send.seq = 1; 
+}
+
+void sendCAN_Messages(){ // Call this function preodically to send the messages use IntervalTimer
+  // Lets show how it works for sending the time
+  unsigned long time_now = now(); // Get current time
+  int32_t ind = 0; 
+  buffer_append_uint32(to_send.buf, time_now, &ind); // Populate the message data 
+  Can0.write(to_send); // Send message (call this for every message to be sent)
+}
+
+void setup(void){
+	Serial.begin(9600);
+	initCAN_Messages(); // Call the function to inicialise all you CAN Messages
+	// Setup the CAN
+	#if defined(__IMXRT1062__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		Can0.begin(); // Inicialise CAN BUS
+		Can0.setBaudRate(500000); // Define CAN BaudRate
+
+		// FIFO allows ordered receptions, Mailboxes can receive in any order as long as a slot is empty. 
+		// You can have FIFO and Mailboxes combined, for example, assign a Mailbox to receive a filtered ID in 
+		// it's own callback, so a separate callback will fire when your critical frame is received. 
+		// With FIFO alone you have only 1 callback essentially. 
+		// In either case Teensy is fast enough to receive all critical frames without filters 
+		// unless you are in non-interrupt mode or your loop code is causing delays...
+
+		// Either use Mailboxes or FIFO if you are not using filters
+		Can0.setMaxMB(16); // Teensy 3.X have only 16 Mailboxes per CAN Channel Teensy 4.X has 64
+		Can0.enableMBInterrupts();
+
+		// Can0.enableFIFO();
+		// Can0.enableFIFOInterrupt();
+
+	#elif defined(__AVR_AT90CAN32__) || defined(__AVR_AT90CAN64__) || defined(__AVR_AT90CAN128__)
+		if( Can0.init(CAN_BPS_500K)){
+			Serial.println("CAN Init OK!");
+		}
+		else{
+			Serial.println("CAN Init Failed!");
+		}
+	#endif
+	Can0.attachObj(&canMessageHandler);
+	
+	#if defined(__AVR_AT90CAN32__) || defined(__AVR_AT90CAN64__) || defined(__AVR_AT90CAN128__)  
+		Can0.setNumTXBoxes(1);    // Use all MOb (only 6x on the ATmegaxxM1 series) for receiving.
+
+		//standard  
+		Can0.setRXFilter(1, 0, 0, false);       //catch all mailbox
+		Can0.setRXFilter(2, 0, 0, false);       //catch all mailbox
+		Can0.setRXFilter(3, 0, 0, false);       //catch all mailbox
+		Can0.setRXFilter(4, 0, 0, false);       //catch all mailbox
+		Can0.setRXFilter(5, 0, 0, false);       //catch all mailbox
+	#endif
+		canMessageHandler.attachGeneralHandler();
+
+	#if defined(__IMXRT1062__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
+		Can0.mailboxStatus(); // This prints the mailboxes status, is also works when using FIFO
+	#endif
+  
+}
+
+void loop(void)
+{
+  // If you want to print something available on the CAN Bus check the CAN_TSB.h to see the structs used.
+  // As an example lets print the battery current
+  Serial.println(canMessageHandler.bat.voltage);
+
+  // To send mesages:
+  sendCAN_Messages();
+  delay(1000);
+}
+```
+
+---

--- a/throttle_rework/src/OCEANOS_CAN/buffer.cpp
+++ b/throttle_rework/src/OCEANOS_CAN/buffer.cpp
@@ -1,0 +1,209 @@
+/*
+	Copyright 2012-2018 Benjamin Vedder	benjamin@vedder.se
+	This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+
+#include "buffer.h"
+#include <math.h>
+#include <stdbool.h>
+
+void buffer_append_int8(uint8_t* buffer, int8_t number, int32_t *index) {
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_uint8(uint8_t* buffer, uint8_t number, int32_t *index) {
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_int16(uint8_t* buffer, int16_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_uint16(uint8_t* buffer, uint16_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_int32(uint8_t* buffer, int32_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 24;
+	buffer[(*index)++] = number >> 16;
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_uint32(uint8_t* buffer, uint32_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 24;
+	buffer[(*index)++] = number >> 16;
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_int64(uint8_t* buffer, int64_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 56;
+	buffer[(*index)++] = number >> 48;
+	buffer[(*index)++] = number >> 40;
+	buffer[(*index)++] = number >> 32;
+	buffer[(*index)++] = number >> 24;
+	buffer[(*index)++] = number >> 16;
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_uint64(uint8_t* buffer, uint64_t number, int32_t *index) {
+	buffer[(*index)++] = number >> 56;
+	buffer[(*index)++] = number >> 48;
+	buffer[(*index)++] = number >> 40;
+	buffer[(*index)++] = number >> 32;
+	buffer[(*index)++] = number >> 24;
+	buffer[(*index)++] = number >> 16;
+	buffer[(*index)++] = number >> 8;
+	buffer[(*index)++] = number;
+}
+
+void buffer_append_float8(uint8_t* buffer, float number, float scale, int32_t *index) {
+    buffer_append_int8(buffer, (int8_t)(number * scale), index);
+}
+
+
+void buffer_append_float16(uint8_t* buffer, float number, float scale, int32_t *index) {
+    buffer_append_int16(buffer, (int16_t)(number * scale), index);
+}
+
+void buffer_append_float32(uint8_t* buffer, float number, float scale, int32_t *index) {
+    buffer_append_int32(buffer, (int32_t)(number * scale), index);
+}
+
+void buffer_append_double64(uint8_t* buffer, double number, double scale, int32_t *index) {
+	buffer_append_int64(buffer, (int64_t)(number * scale), index);
+}
+
+void buffer_append_float32_auto(uint8_t* buffer, float number, int32_t *index) {
+	int e = 0;
+	float sig = frexpf(number, &e);
+	float sig_abs = fabsf(sig);
+	uint32_t sig_i = 0;
+
+	if (sig_abs >= 0.5) {
+		sig_i = (uint32_t)((sig_abs - 0.5f) * 2.0f * 8388608.0f);
+		e += 126;
+	}
+
+	uint32_t res = ((e & 0xFF) << 23) | (sig_i & 0x7FFFFF);
+	if (sig < 0) {
+		res |= 1 << 31;
+	}
+
+	buffer_append_uint32(buffer, res, index);
+}
+
+int8_t buffer_get_int8(const uint8_t *buffer, int32_t *index) {
+	return (int8_t) buffer[*index++];
+}
+
+uint8_t buffer_get_uint8(const uint8_t *buffer, int32_t *index) {
+	return (uint8_t) buffer[*index++];
+}
+
+int16_t buffer_get_int16(const uint8_t *buffer, int32_t *index) {
+	int16_t res =	((uint16_t) buffer[*index]) << 8 |
+					((uint16_t) buffer[*index + 1]);
+	*index += 2;
+	return res;
+}
+
+uint16_t buffer_get_uint16(const uint8_t *buffer, int32_t *index) {
+	uint16_t res = 	((uint16_t) buffer[*index]) << 8 |
+					((uint16_t) buffer[*index + 1]);
+	*index += 2;
+	return res;
+}
+
+int32_t buffer_get_int32(const uint8_t *buffer, int32_t *index) {
+	int32_t res =	((uint32_t) buffer[*index]) << 24 |
+					((uint32_t) buffer[*index + 1]) << 16 |
+					((uint32_t) buffer[*index + 2]) << 8 |
+					((uint32_t) buffer[*index + 3]);
+	*index += 4;
+	return res;
+}
+
+uint32_t buffer_get_uint32(const uint8_t *buffer, int32_t *index) {
+	uint32_t res =	((uint32_t) buffer[*index]) << 24 |
+					((uint32_t) buffer[*index + 1]) << 16 |
+					((uint32_t) buffer[*index + 2]) << 8 |
+					((uint32_t) buffer[*index + 3]);
+	*index += 4;
+	return res;
+}
+
+int64_t buffer_get_int64(const uint8_t *buffer, int32_t *index) {
+	int64_t res =	((uint64_t) buffer[*index]) << 56 |
+					((uint64_t) buffer[*index + 1]) << 48 |
+					((uint64_t) buffer[*index + 2]) << 40 |
+					((uint64_t) buffer[*index + 3]) << 32 |
+					((uint64_t) buffer[*index + 4]) << 24 |
+					((uint64_t) buffer[*index + 5]) << 16 |
+					((uint64_t) buffer[*index + 6]) << 8 |
+					((uint64_t) buffer[*index + 7]);
+	*index += 8;
+	return res;
+}
+
+uint64_t buffer_get_uint64(const uint8_t *buffer, int32_t *index) {
+	uint64_t res =	((uint64_t) buffer[*index]) << 56 |
+					((uint64_t) buffer[*index + 1]) << 48 |
+					((uint64_t) buffer[*index + 2]) << 40 |
+					((uint64_t) buffer[*index + 3]) << 32 |
+					((uint64_t) buffer[*index + 4]) << 24 |
+					((uint64_t) buffer[*index + 5]) << 16 |
+					((uint64_t) buffer[*index + 6]) << 8 |
+					((uint64_t) buffer[*index + 7]);
+	*index += 8;
+	return res;
+}
+
+float buffer_get_float8(const uint8_t *buffer, float scale, int32_t *index) {
+    return (float)buffer_get_int8(buffer, index) / scale;
+}
+
+float buffer_get_float16(const uint8_t *buffer, float scale, int32_t *index) {
+    return (float)buffer_get_int16(buffer, index) / scale;
+}
+
+float buffer_get_float32(const uint8_t *buffer, float scale, int32_t *index) {
+    return (float)buffer_get_int32(buffer, index) / scale;
+}
+
+double buffer_get_double64(const uint8_t *buffer, double scale, int32_t *index) {
+    return (double)buffer_get_int64(buffer, index) / scale;
+}
+
+float buffer_get_float32_auto(const uint8_t *buffer, int32_t *index) {
+	uint32_t res = buffer_get_uint32(buffer, index);
+
+	int e = (res >> 23) & 0xFF;
+	uint32_t sig_i = res & 0x7FFFFF;
+	bool neg = res & (1 << 31);
+
+	float sig = 0.0;
+	if (e != 0 || sig_i != 0) {
+		sig = (float)sig_i / (8388608.0 * 2.0) + 0.5;
+		e -= 126;
+	}
+
+	if (neg) {
+		sig = -sig;
+	}
+
+	return ldexpf(sig, e);
+}

--- a/throttle_rework/src/OCEANOS_CAN/buffer.h
+++ b/throttle_rework/src/OCEANOS_CAN/buffer.h
@@ -1,0 +1,47 @@
+/*
+	Copyright 2012-2018 Benjamin Vedder	benjamin@vedder.se
+	This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    */
+    
+#ifndef BUFFER_H_
+#define BUFFER_H_
+
+#include <stdint.h>
+
+void buffer_append_int8(uint8_t* buffer, int8_t number, int32_t *index);
+void buffer_append_uint8(uint8_t* buffer, uint8_t number, int32_t *index);
+void buffer_append_int16(uint8_t* buffer, int16_t number, int32_t *index);
+void buffer_append_uint16(uint8_t* buffer, uint16_t number, int32_t *index);
+void buffer_append_int32(uint8_t* buffer, int32_t number, int32_t *index);
+void buffer_append_uint32(uint8_t* buffer, uint32_t number, int32_t *index);
+void buffer_append_int64(uint8_t* buffer, int64_t number, int32_t *index);
+void buffer_append_uint64(uint8_t* buffer, uint64_t number, int32_t *index);
+void buffer_append_float8(uint8_t* buffer, float number, float scale, int32_t *index);
+void buffer_append_float16(uint8_t* buffer, float number, float scale, int32_t *index);
+void buffer_append_float32(uint8_t* buffer, float number, float scale, int32_t *index);
+void buffer_append_double64(uint8_t* buffer, double number, double scale, int32_t *index);
+void buffer_append_float32_auto(uint8_t* buffer, float number, int32_t *index);
+int8_t buffer_get_int8(const uint8_t *buffer, int32_t *index);
+uint8_t buffer_get_uint8(const uint8_t *buffer, int32_t *index);
+int16_t buffer_get_int16(const uint8_t *buffer, int32_t *index);
+uint16_t buffer_get_uint16(const uint8_t *buffer, int32_t *index);
+int32_t buffer_get_int32(const uint8_t *buffer, int32_t *index);
+uint32_t buffer_get_uint32(const uint8_t *buffer, int32_t *index);
+int64_t buffer_get_int64(const uint8_t *buffer, int32_t *index);
+uint64_t buffer_get_uint64(const uint8_t *buffer, int32_t *index);
+float buffer_get_float8(const uint8_t *buffer, float scale, int32_t *index);
+float buffer_get_float16(const uint8_t *buffer, float scale, int32_t *index);
+float buffer_get_float32(const uint8_t *buffer, float scale, int32_t *index);
+double buffer_get_double64(const uint8_t *buffer, double scale, int32_t *index);
+float buffer_get_float32_auto(const uint8_t *buffer, int32_t *index);
+
+#endif /* BUFFER_H_ */

--- a/throttle_rework/src/VescCAN/VescCAN.cpp
+++ b/throttle_rework/src/VescCAN/VescCAN.cpp
@@ -1,0 +1,66 @@
+#include "VescCAN.h"
+VescCAN::VescCAN(int VescId){
+    id = VescId;
+    setCurrent.flags.extended = true;
+    setCurrentRelative.flags.extended = true;
+    setDutyCycle.flags.extended = true;
+    setBrakeCurrent.flags.extended = true;
+    setRPMs.flags.extended = true;
+    setBrakeCurrentRelative.flags.extended = true;
+    setMotorCurrentLimit.flags.extended = true;
+    setStoreMotorCurrentLimit.flags.extended = true;
+    setInputCurrentLimit.flags.extended = true;
+    setStoreInputCurrentLimit.flags.extended = true;
+
+    setCurrent.len = 4;
+    setCurrentRelative.len = 4;
+    setDutyCycle.len = 4;
+    setBrakeCurrent.len = 4;
+    setRPMs.len = 4;
+    setBrakeCurrentRelative.len = 8;
+    setMotorCurrentLimit.len = 8;
+    setStoreMotorCurrentLimit.len = 8;
+    setInputCurrentLimit.len = 8;
+    setStoreInputCurrentLimit.len = 8;
+
+    setCurrent.id = 0x100 | VescId;
+    setCurrentRelative.id = 0xA00 | VescId;
+    setDutyCycle.id = 0x000 | VescId;
+    setBrakeCurrent.id = 0x200 | VescId;
+    setRPMs.id = 0x300 | VescId;
+    setBrakeCurrentRelative.id = 0xB00 | VescId;
+    setMotorCurrentLimit.id = 0x1500 | VescId;
+    setStoreMotorCurrentLimit.id = 0x1600 | VescId;
+    setInputCurrentLimit.id = 0x1700 | VescId;
+    setStoreInputCurrentLimit.id = 0x1800 | VescId;
+}
+
+void VescCAN::setMotorCurrent(float current){
+	int32_t ind = 0;
+	buffer_append_int32( setCurrent.buf , current*1000, &ind);
+    //Serial.println((String)"setMotorCurrent: " + current + " ID: " + this->id);
+
+}
+
+void VescCAN::setMotorCurrentPercentage(int32_t percentage){
+	int32_t ind = 0;
+	buffer_append_int32( setCurrentRelative.buf, percentage*1000, &ind);
+    //Can0.write(setCurrentRelative);
+}
+void VescCAN::setRPM(int32_t rpm){
+	int32_t ind = 0;
+	buffer_append_int32( setRPMs.buf , rpm, &ind);
+}
+
+void VescCAN::printMotorCurrent(){
+	Serial.print("MB "); Serial.print(setCurrent.mb);
+	Serial.print("  OVERRUN: "); Serial.print(setCurrent.flags.overrun);
+	Serial.print("  LEN: "); Serial.print(setCurrent.len);
+	Serial.print(" EXT: "); Serial.print(setCurrent.flags.extended);
+	Serial.print(" TS: "); Serial.print(setCurrent.timestamp);
+	Serial.print(" ID: "); Serial.print(setCurrent.id, HEX);
+	Serial.print(" Buffer: ");
+	for ( uint8_t i = 0; i < setCurrent.len; i++ ) {
+		Serial.print(setCurrent.buf[i], HEX); Serial.print(" ");
+	} Serial.println();
+}

--- a/throttle_rework/src/VescCAN/VescCAN.h
+++ b/throttle_rework/src/VescCAN/VescCAN.h
@@ -1,0 +1,25 @@
+#include "../OCEANOS_CAN/OCEANOS_CAN.h"
+class VescCAN {  
+    private:
+        int32_t id;
+        CAN_message_t setCurrentRelative;
+        CAN_message_t setDutyCycle;
+        CAN_message_t setBrakeCurrent;
+        CAN_message_t setBrakeCurrentRelative;
+        CAN_message_t setMotorCurrentLimit;
+        CAN_message_t setStoreMotorCurrentLimit;
+        CAN_message_t setInputCurrentLimit;
+        CAN_message_t setStoreInputCurrentLimit;
+
+
+    public:
+        CAN_message_t setCurrent;
+		CAN_message_t setRPMs;
+
+        VescCAN(int VescId);
+        void setMotorCurrent(float current);
+        void setMotorCurrentPercentage(int32_t percentage);
+		void printMotorCurrent();
+		void setRPM(int32_t rpm);
+		void printRPM();
+};

--- a/throttle_rework/throttle_rework.ino
+++ b/throttle_rework/throttle_rework.ino
@@ -1,0 +1,177 @@
+//VESC CANBus ID
+#define VESC_ID 110
+#define CAN_BAUD_RATE 500000    //in bps
+// LEITOURGEI MONO GIA HAND!!!!
+#define THROTTLE_PIN1 6
+#define VOLTAGE_LIMIT 0
+#define REVERSE_PIN 6
+
+#define HAND_MIN 340
+#define HAND_MAX 60
+#define HAND_LIM 335     //355 - 3 
+
+#define WINDOW_LENGTH 50
+#include "src/OCEANOS_CAN/OCEANOS_CAN.h"  //TODO: rename and expand library
+#include "src/VescCAN/VescCAN.h"
+
+//Can0 here is used purely for listening to Can0
+CAN_message_t can_message;
+FlexCAN_T4<CAN1, RX_SIZE_256, TX_SIZE_16> Can0;
+OCEANOS_CAN Can_listen(VESC_ID);
+VescCAN motor1(VESC_ID);
+
+
+int angle;
+int start_angle;
+int start_angle2;
+int8_t throttle;
+uint8_t status;
+bool neutral_to_start;
+elapsedMillis sinceLastCurrent_Write;
+
+int selected_throttle = THROTTLE_PIN1;
+
+float maximum_current = 400;
+
+bool reverse;
+bool reverse_pin;
+bool fl_hand_throttle = 1;
+float motor_current = 0;
+bool wasStopped = true;
+bool startUpEnd = false;
+unsigned long startUpEndTime = 0;
+unsigned long lastIncrementTime = 0;
+float sweepCurrent = 40;
+int window[WINDOW_LENGTH];  //for denoising the input signal
+uint64_t sum = 0;
+int w = 0;
+void setMotorCurrent(float current);
+void neutral_to_start_f();
+void setup() {
+  for (int i = 0; i < WINDOW_LENGTH; i++) {
+    window[i] = 0;
+  }
+  neutral_to_start = false;
+  Serial.begin(115200);  // NOTE BAUD RATE
+
+
+  Can0.begin();
+  Can0.setMaxMB(16);
+  Can0.enableMBInterrupts();
+
+  Can0.setBaudRate(CAN_BAUD_RATE);     //CANBUS BAUD RATE
+  Can0.attachObj(&Can_listen);
+  Can0.mailboxStatus();
+  //Here you can do some filtering if you'd like, though it's not really neccessary here(plus teensy is really fast)
+  Can_listen.attachGeneralHandler();
+  delay(200);  //wait for Can_listen to catch a packet
+  Can0.events();
+  pinMode(REVERSE_PIN, INPUT_PULLUP);  //reverse switch
+
+  neutral_to_start_f();
+  Serial.println("Exit start");
+}
+
+void loop() {
+  safety();
+  //Take mean of 100 inputs, so that we minimize input noise from the throttles
+  //exe geia vedder 8ee pou evales to reverse sto mpp kai mas vazeis na kanoume olo malakies
+  Can0.events();
+
+  if (w == WINDOW_LENGTH) w = 0;
+  sum -= window[w];
+  window[w] = (int)analogRead(THROTTLE_PIN1) * 360 / 1024;
+  Serial.println((String)analogRead(THROTTLE_PIN1));
+  sum += window[w++];
+  angle = (int)sum / WINDOW_LENGTH;
+
+
+  //reverse logic -> Go to reverse (and back) only on Neutral
+  reverse_pin = digitalRead(REVERSE_PIN);
+  if (angle > HAND_LIM) {
+    reverse = !reverse_pin;
+    //Serial.println(angle);
+  }
+  //toggle throttle logic
+  if(angle < HAND_MAX) angle = HAND_MAX;
+
+
+  /*reverse*/
+  if (reverse) {
+    if (wasStopped)
+      throttle = map(angle, HAND_MIN, HAND_MAX, -15, -100);  // maped
+    else
+      throttle = map(angle, HAND_MIN, HAND_MAX, -5, -100);
+  }
+  /*forward*/
+  if (!reverse) {
+    if (wasStopped)
+      throttle = map(angle, HAND_MIN, HAND_MAX, 15, 100);
+    else
+      throttle = map(angle, HAND_MIN, HAND_MAX, 5, 100);
+  }
+  /*Neutral*/
+  if (angle > HAND_LIM) {
+    throttle = 0;
+    wasStopped = true;
+  }
+
+
+  if (wasStopped == true && throttle != 0 && (millis() - lastIncrementTime) > 100) {
+    Serial.println(sweepCurrent);
+    lastIncrementTime = millis();
+    setMotorCurrent(sweepCurrent);
+    sweepCurrent += 1;
+    if (sweepCurrent > 50) {
+      startUpEnd = true;
+      wasStopped = false;
+      startUpEndTime = millis();
+      sweepCurrent = 40;
+    }
+
+  } 
+  
+  else {
+    motor_current = throttle * maximum_current / 100;
+    setMotorCurrent(motor_current);
+  }
+}
+//On device startup(or after reconnecting to motor), ensure that throttle is in position 0
+void neutral_to_start_f() {
+  while (!neutral_to_start) {
+    Can0.events();
+    reverse_pin = digitalRead(REVERSE_PIN);
+    
+    setMotorCurrent(0);
+    
+    start_angle = (int)analogRead(selected_throttle) * 360 / 1024;
+
+    delay(250);
+
+    start_angle2 = (int)analogRead(selected_throttle) * 360 / 1024;
+
+    if ((start_angle > HAND_LIM) && (start_angle2 > HAND_LIM)) neutral_to_start = true;
+    int test_throttle = map(start_angle, HAND_MIN, HAND_MAX, -5, -100);
+    delay(250);
+    Serial.println((String) " Here: " + "Can_listen.motor.voltage: " + Can_listen.motor.voltage + "  neutral_to_start: " + neutral_to_start + " start_angle: " + start_angle + " " + start_angle2 +"Test Throttle:  " + test_throttle);
+  }
+}
+
+//turn apropriate light when toggling the switch, but change input device only when at low 
+//this shit don't work
+void setMotorCurrent(float current) {
+  if (sinceLastCurrent_Write  < 100) return;
+  else sinceLastCurrent_Write -= 100;
+  motor1.setMotorCurrent(current);
+  Can0.write(motor1.setCurrent);
+  Serial.println((String) "setMotorCurrent = " + current);
+}
+
+//to prevent accidental motor activation on the event throttle stays powered in 
+void safety(){
+  if(Can_listen.motor.voltage <= VOLTAGE_LIMIT) {
+    Serial.println("voltage = "+ (String)VOLTAGE_LIMIT+ " or Packet not found");
+    Serial.println("place throttle to neutral position");
+    neutral_to_start_f();
+  }
+}


### PR DESCRIPTION
Modified version of the code used during MEBC 2023 by the OCEANOS team. Capped the output rate of CAN packets at 10Hz, so as not to congest the CAN Bus with useless packets. Reworked the included libraries, so as to be easier to understand.  IMPORTANT: Code tested for usage with Arduino IDE, with TeensyDuino installed, using its included FlexCAN_T4 library for CAN communication.